### PR TITLE
An option to recursively enumerate subfolders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN mkdir -p /data /tmp/converted_files
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/out /usr/src/app
 
-ENTRYPOINT [ "dotnet", "AnnoyingCRLF.dll" ]
+ENTRYPOINT [ "dotnet", "AnnoyingCRLF.dll", "--" ]

--- a/Program.fs
+++ b/Program.fs
@@ -15,9 +15,15 @@ let writeToFile (file: string) =
 
 [<EntryPoint>]
 let main argv =
-    argv
+    let options, patterns =
+        if argv.Length > 0 && argv[0] = "-r" then
+            EnumerationOptions(RecurseSubdirectories=true), argv[1..]
+        else
+            EnumerationOptions(), argv
+
+    patterns
     |> Array.map (fun x ->
-        Directory.GetFiles("/data", x)
+        Directory.GetFiles("/data", x, options)
         |> Array.map (Path.GetFullPath >> writeToFile)
         |> Async.Parallel
         |> Async.RunSynchronously)


### PR DESCRIPTION
Fixes #3.
If you use `-r` as the first parameter, it will also go through subfolders.
Please add `hacktoberfest-accepted` as a label to this pr :)